### PR TITLE
Don't patch requests for now

### DIFF
--- a/packages/pythonlab_setup/pyproject.toml
+++ b/packages/pythonlab_setup/pyproject.toml
@@ -5,4 +5,4 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pythonlab_setup"
 version = "0.0.1"
-dependencies = ["requests", "matplotlib"]
+dependencies = ["matplotlib"]

--- a/packages/pythonlab_setup/pythonlab_setup/patch_requests.py
+++ b/packages/pythonlab_setup/pythonlab_setup/patch_requests.py
@@ -5,6 +5,11 @@ import importlib
 # Patch requests to proxy all request through the code.org xhr endpoint.
 # This is necessary to only allow requests to an allow-list of domains.
 
+# TODO: Patch all requests methods. Once we've patched all the methods and
+# curriculum wants to expose requests to users, call reload_requests_and_patch
+# from setup_pythonlab. See linked ticket for more information.
+# https://codedotorg.atlassian.net/browse/CT-537
+
 def get_proxy_path(host, url, channel_id):
     return f"{host}/xhr?u={urllib.parse.quote(url, safe='/:')}&c={urllib.parse.quote(channel_id, safe='/:')}"
 
@@ -22,8 +27,6 @@ def reload_requests_and_patch(host, channel_id):
 def patch_requests(host, channel_id):
     _old_get = requests.get
 
-    # TODO: Patch the rest of the methods
-    # https://codedotorg.atlassian.net/browse/CT-537
     def get(url, params=None, **kwargs):
         url = get_proxy_path(host, url, channel_id)
         return _old_get(url, params, **kwargs)

--- a/packages/pythonlab_setup/pythonlab_setup/patch_requests.py
+++ b/packages/pythonlab_setup/pythonlab_setup/patch_requests.py
@@ -5,9 +5,9 @@ import importlib
 # Patch requests to proxy all request through the code.org xhr endpoint.
 # This is necessary to only allow requests to an allow-list of domains.
 
-# TODO: Patch all requests methods. Once we've patched all the methods and
-# curriculum wants to expose requests to users, call reload_requests_and_patch
-# from setup_pythonlab. See linked ticket for more information.
+# TODO: Patch all requests methods and add requests as a dependency in pyproject.toml.
+# Once we've patched all the methods and curriculum wants to expose requests to users,
+# call reload_requests_and_patch from setup_pythonlab. See linked ticket for more information.
 # https://codedotorg.atlassian.net/browse/CT-537
 
 def get_proxy_path(host, url, channel_id):

--- a/packages/pythonlab_setup/pythonlab_setup/setup_pythonlab.py
+++ b/packages/pythonlab_setup/pythonlab_setup/setup_pythonlab.py
@@ -1,6 +1,4 @@
 from .patch_matplotlib import patch_matplotlib
-from .patch_requests import reload_requests_and_patch
 
-def setup_pythonlab(matplotlib_img_tag, host, channel_id):
+def setup_pythonlab(matplotlib_img_tag):
   patch_matplotlib(matplotlib_img_tag)
-  reload_requests_and_patch(host, channel_id)


### PR DESCRIPTION
Curriculum has decided against needing to make http requests for the data science unit. Since there are some complexities to figure out with fully patching the `requests` module, this PR removes the patch from the `setup_pythonlab` method and removes `requests` as a dependency of the setup package. We need to remove it as a dependency so we don't have to import the package when running the setup method.

There is a [follow up ticket](https://codedotorg.atlassian.net/browse/CT-537) to track the work to patch requests once we decide that we need to let students make http requests. 