### PR TITLE
Make unittest_runner package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The current patches are:
 All Python Lab programs are prefixed with `setup_pythonlab()`, the method this package exposes, which only applies
 the matplotlib patch for now.
 
+## unittest_runner
+This tests adds some customization to the output of unit tests, and has a function to either run validation tests
+(more customized) or student tests (less customized).
+
 ## Setup
 - Install `pyenv`. 
     - See instructions [here](https://github.com/pyenv/pyenv?tab=readme-ov-file#getting-pyenv)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The current patches are:
 - We patch `requests` in order to route requests through code.org's request proxy. This protects students
   by only allowing requests to an allow-list of urls.
 
-All Python Lab programs are prefixed with `setup_pythonlab()`, the method this package exposes, which applies
-the above patches.
+All Python Lab programs are prefixed with `setup_pythonlab()`, the method this package exposes, which only applies
+the matplotlib patch for now.
 
 ## Setup
 - Install `pyenv`. 

--- a/packages/unittest_runner/pyproject.toml
+++ b/packages/unittest_runner/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "unittest_runner"
+version = "0.0.1"
+dependencies = ["unittest"]

--- a/packages/unittest_runner/unittest_runner/__init__.py
+++ b/packages/unittest_runner/unittest_runner/__init__.py
@@ -1,0 +1,1 @@
+from .run_tests import run_student_tests, run_validation_tests

--- a/packages/unittest_runner/unittest_runner/run_tests.py
+++ b/packages/unittest_runner/unittest_runner/run_tests.py
@@ -1,9 +1,13 @@
 import unittest
 from .validation_runner import ValidationTestResult
 
+# Run the tests in the given file pattern and display the results to the user.
+# Validation tests use the ValidationTestResult class to display only the short description of the test.
 def run_validation_tests(file_pattern):
   run_tests(file_pattern, ValidationTestResult)
 
+# Run the tests in the given file pattern and display the results to the user.
+# Student tests use the standard TextTestResult class to display the test name and short description.
 def run_student_tests(file_pattern):
   run_tests(file_pattern, unittest.TextTestResult)
 

--- a/packages/unittest_runner/unittest_runner/run_tests.py
+++ b/packages/unittest_runner/unittest_runner/run_tests.py
@@ -1,0 +1,14 @@
+import unittest
+from .validation_runner import ValidationTestResult
+
+def run_validation_tests(file_pattern):
+  run_tests(file_pattern, ValidationTestResult)
+
+def run_student_tests(file_pattern):
+  run_tests(file_pattern, unittest.TextTestResult)
+
+def run_tests(file_pattern, resultclass):
+  loader = unittest.TestLoader()
+  test_suite = loader.discover('.', file_pattern)
+  runner = unittest.TextTestRunner(verbosity=2, resultclass=resultclass)
+  result = runner.run(test_suite)

--- a/packages/unittest_runner/unittest_runner/validation_runner.py
+++ b/packages/unittest_runner/unittest_runner/validation_runner.py
@@ -1,0 +1,13 @@
+
+from unittest import TextTestResult
+
+class ValidationTestResult(TextTestResult):
+  # The default behavior is to display the test name and short description.
+  # We want to display only the short description if it exists, otherwise just the test name.
+  # Students don't see the tests, so we don't need to display the test name.
+  def getDescription(self, test):
+    doc_first_line = test.shortDescription()
+    if doc_first_line:
+      return doc_first_line
+    else:
+      return str(test)

--- a/packages/unittest_runner/unittest_runner/validation_runner.py
+++ b/packages/unittest_runner/unittest_runner/validation_runner.py
@@ -5,6 +5,7 @@ class ValidationTestResult(TextTestResult):
   # The default behavior is to display the test name and short description.
   # We want to display only the short description if it exists, otherwise just the test name.
   # Students don't see the tests, so we don't need to display the test name.
+  # See this PR for details: https://github.com/code-dot-org/pythonlab-packages/pull/3
   def getDescription(self, test):
     doc_first_line = test.shortDescription()
     if doc_first_line:


### PR DESCRIPTION
This PR makes a package that exports functions to run student and validation tests. Currently the basic version of this logic is in a [string in Typescript](https://github.com/code-dot-org/code-dot-org/blob/fb668299a6e69ad1654e27b912c2ac4b1bb9b086/apps/src/pythonlab/pythonHelpers/scripts.ts#L4) in the main repo. This extracts that logic out and makes an improvement to the output.

The improvement here is for validation tests we only show the short description of the test, if it exists, rather than the test name and file name (the default behavior). This will allow friendlier unit test output for level tests. The output still isn't great, but we are in the midst of figuring out what we want the output to be so I kept this very simple for now, and we can iteratively improve on it.

I made this improvement by extending [TextTestResult](https://docs.python.org/3/library/unittest.html#unittest.TextTestResult) and overriding the `getDescription` method. If we want to make further changes to how we show output, we can update this class.

## Before
![Screenshot 2024-07-24 at 11 33 28 AM](https://github.com/user-attachments/assets/704f8a66-023b-4157-9027-0283ee1a5e85)

## After
This requires a change on the frontend, which will be covered in a separate PR once this is in.

![Screenshot 2024-07-24 at 11 27 33 AM](https://github.com/user-attachments/assets/23f1a3d2-8978-49db-85d6-781bbfec6cb4)
