### PR TITLE
Create a teardown function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@ This repository consists of packages for use in Python Lab. This can contain any
 students or any patches we want to apply to student code. Here are the current packages:
 
 ### pythonlab_setup
-This package handles setup for Python Lab. Specifically, it patches libraries for use in Python Lab.
+This package handles setup and teardown for Python Lab. For setup, it patches libraries for use in Python Lab.
 The current patches are:
 - We patch `matplotlib` in order to display graphs correctly. The patch updates the `show` method to send
   a base64 encoded string for display in Python Lab.
 - We patch `requests` in order to route requests through code.org's request proxy. This protects students
   by only allowing requests to an allow-list of urls.
 
-All Python Lab programs are prefixed with `setup_pythonlab()`, the method this package exposes, which only applies
-the matplotlib patch for now.
+We run `setup_pythonlab()`, a method this package exposes, before each student run, which only applies
+the matplotlib patch for now. We also run `teardown_pythonlab()` after each run, which flushes stdout and
+changes directory to the home folder.
 
 ## unittest_runner
 This tests adds some customization to the output of unit tests, and has a function to either run validation tests

--- a/packages/pythonlab_setup/pyproject.toml
+++ b/packages/pythonlab_setup/pyproject.toml
@@ -4,5 +4,5 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonlab_setup"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = ["matplotlib"]

--- a/packages/pythonlab_setup/pythonlab_setup/__init__.py
+++ b/packages/pythonlab_setup/pythonlab_setup/__init__.py
@@ -1,1 +1,2 @@
 from .setup_pythonlab import setup_pythonlab
+from .teardown_pythonlab import teardown_pythonlab

--- a/packages/pythonlab_setup/pythonlab_setup/teardown_pythonlab.py
+++ b/packages/pythonlab_setup/pythonlab_setup/teardown_pythonlab.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+def teardown_pythonlab(home_folder):
+  flush_sysout()
+  go_home(home_folder)
+
+# Ensure stdout is flushed so all of of a user's prints are visible to them.
+def flush_sysout():
+  sys.stdout.flush()
+  os.fsync(sys.stdout.fileno())
+
+def go_home(home_folder):
+  os.chdir(home_folder)


### PR DESCRIPTION
This PR adds a `teardown_pythonlab` function that does the following:
- flush system out to ensure all prints show up in the console. This is ported over from a [string in the apps directory](https://github.com/code-dot-org/code-dot-org/blob/522e87478dcb3eb51f6fcbd8ab4010ee7e0d331f/apps/src/pythonlab/pythonHelpers/patches.ts#L5).
- Changes directory back to the given home directory. This is to fix an issue where if the student switches directory during their code execution, we encounter buggy behavior, such as code updates not showing up. This is because we depend on the user starting from the `Files` directory in pyodide to load their code correctly.

I put this function in the `pythonlab_setup` package, since it's a twin to `setup_pythonlab()`. If anyone can think of a better name for this package now that it includes setup and teardown, let me know (or let me know if `pythonlab_setup` still makes sense!)

Once this is in (and I change the name of the package if we think that's valuable), I will update the python lab side to use this function rather than the hard-coded patch.

Ticket: [CT-703](https://codedotorg.atlassian.net/browse/CT-703)